### PR TITLE
feat(watch): support .* file extension for matching all files

### DIFF
--- a/src/extensions/watch.coffee
+++ b/src/extensions/watch.coffee
@@ -36,8 +36,11 @@ module.exports = (files, options = {}) ->
         else
           watch file unless file is process.argv[1]
 
+  fileTypeIsToWatch = (file) ->
+     return extensions[0] is '.*' || (~ extensions.indexOf path.extname file)
+
   watch = (file) =>
-    return unless ~ extensions.indexOf path.extname file
+    return unless fileTypeIsToWatch file
 
     fs.watchFile file, { interval, persistent : no }, (curr, prev) =>
       if curr.mtime > prev.mtime


### PR DESCRIPTION
This change fixes #5 

Note: When running tests, I have noticed that watch extension's tests are skipped. Is there a reason for that?